### PR TITLE
Fix deploy job access to build artifacts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,7 +79,7 @@ deploy_deb:
   stage: deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main", "size:large"]
-  needs: ["test_deb"]
+  needs: ["build_deb", "test_deb"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   rules:


### PR DESCRIPTION
By adding the `needs: ["test_deb"]` in a previous PR, the deploy job stopped receiving artifacts from `build_deb`. This PR fixes it.