### PR TITLE
Add gnupg as a runtime dependency

### DIFF
--- a/config/projects/datadog-signing-keys.rb
+++ b/config/projects/datadog-signing-keys.rb
@@ -32,6 +32,8 @@ description 'Datadog Signing Keys
 
 dependency 'datadog-signing-keys'
 
+runtime_dependency 'gnupg'
+
 exclude '**/.git'
 exclude '**/bundler/git'
 


### PR DESCRIPTION
gnupg is not always present (especially on newer systems, where apt depends on gpgv, which is a stripped down version that we can't work with).