### PR TITLE
Ensure /etc/apt keyring is created if source list file doesn't use proper signed-by

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -164,7 +164,7 @@ generate_testing_repo:
   stage: deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main", "size:large"]
-  needs: ["build_deb", "test_debian_7_signed_by", "test_debian_7_not_signed_by" "test_debian_10_signed_by", "test_debian_10_not_signed_by", "test_ubuntu_14_signed_by", "test_ubuntu_14_not_signed_by", "test_ubuntu_18_signed_by", "test_ubuntu_18_not_signed_by"]
+  needs: ["build_deb", "test_debian_7_signed_by", "test_debian_7_not_signed_by", "test_debian_10_signed_by", "test_debian_10_not_signed_by", "test_ubuntu_14_signed_by", "test_ubuntu_14_not_signed_by", "test_ubuntu_18_signed_by", "test_ubuntu_18_not_signed_by"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,7 +72,7 @@ build_deb:
     - echo -e "deb http://archive.debian.org/debian wheezy main\ndeb http://archive.debian.org/debian-security wheezy/updates main" > /etc/apt/sources.list
     - apt-get update -o Acquire::Check-Valid-Until=false
     - apt-get install -y debsig-verify
-    - if [ "USE_SIGNED_BY" = "true" ]; echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important" > ${SOURCES_LIST_FILE}; fi
+    - if [ "USE_SIGNED_BY" = "true" ]; then echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important" > ${SOURCES_LIST_FILE}; fi
     # apt-get in Debian 7 doesn't work with local packages
     - dpkg -i $OMNIBUS_PACKAGE_DIR/*.deb
     - rm -f ${SOURCES_LIST_FILE}
@@ -92,7 +92,7 @@ test_debian_7_not_signed_by:
   image: registry.ddbuild.io/images/mirror/debian:10.9
   before_script:
     - apt-get update
-    - if [ "USE_SIGNED_BY" = "true" ]; echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important" > ${SOURCES_LIST_FILE}; fi
+    - if [ "USE_SIGNED_BY" = "true" ]; then echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important" > ${SOURCES_LIST_FILE}; fi
     - apt-get install -y $OMNIBUS_PACKAGE_DIR/*.deb debsig-verify
     - rm -f ${SOURCES_LIST_FILE}
 
@@ -113,7 +113,7 @@ test_debian_10_not_signed_by:
     - apt-get update
     - apt-get install -y debsig-verify
     # apt-get in Ubuntu 14 doesn't work with local packages
-    - if [ "USE_SIGNED_BY" = "true" ]; echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important" > ${SOURCES_LIST_FILE}; fi
+    - if [ "USE_SIGNED_BY" = "true" ]; then echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important" > ${SOURCES_LIST_FILE}; fi
     - dpkg -i $OMNIBUS_PACKAGE_DIR/*.deb
     - rm -f ${SOURCES_LIST_FILE}
     # rebuild the apt database after installing the package with dpkg
@@ -132,7 +132,7 @@ test_ubuntu_14_not_signed_by:
   image: registry.ddbuild.io/images/mirror/ubuntu:18.04
   before_script:
     - apt-get update
-    - if [ "USE_SIGNED_BY" = "true" ]; echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important" > ${SOURCES_LIST_FILE}; fi
+    - if [ "USE_SIGNED_BY" = "true" ]; then echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important" > ${SOURCES_LIST_FILE}; fi
     - apt-get install -y $OMNIBUS_PACKAGE_DIR/*.deb debsig-verify
     - rm -f ${SOURCES_LIST_FILE}
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,8 @@ variables:
   S3_CP_OPTIONS: --only-show-errors --region us-east-1 --sse AES256
   S3_CP_CMD: aws s3 cp $S3_CP_OPTIONS
   TESTING_REPO_DIR: ./testing-repo-dir
+  USR_SHARE_KEYRING: /usr/share/keyrings/datadog-archive-keyring.gpg
+  SOURCES_LIST_FILE: /etc/apt/sources.list.d/datadog.list
 
 .setup_deb_signing_key: &setup_deb_signing_key
   - set +x
@@ -70,8 +72,10 @@ build_deb:
     - echo -e "deb http://archive.debian.org/debian wheezy main\ndeb http://archive.debian.org/debian-security wheezy/updates main" > /etc/apt/sources.list
     - apt-get update -o Acquire::Check-Valid-Until=false
     - apt-get install -y debsig-verify
+    - if [ "USE_SIGNED_BY" = "true" ]; echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important" > ${SOURCES_LIST_FILE}; fi
     # apt-get in Debian 7 doesn't work with local packages
     - dpkg -i $OMNIBUS_PACKAGE_DIR/*.deb
+    - rm -f ${SOURCES_LIST_FILE}
     # rebuild the apt database after installing the package with dpkg
     - apt-get install -f
 
@@ -88,7 +92,9 @@ test_debian_7_not_signed_by:
   image: registry.ddbuild.io/images/mirror/debian:10.9
   before_script:
     - apt-get update
+    - if [ "USE_SIGNED_BY" = "true" ]; echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important" > ${SOURCES_LIST_FILE}; fi
     - apt-get install -y $OMNIBUS_PACKAGE_DIR/*.deb debsig-verify
+    - rm -f ${SOURCES_LIST_FILE}
 
 test_debian_10_signed_by:
   extends: .test_debian_10
@@ -107,7 +113,9 @@ test_debian_10_not_signed_by:
     - apt-get update
     - apt-get install -y debsig-verify
     # apt-get in Ubuntu 14 doesn't work with local packages
+    - if [ "USE_SIGNED_BY" = "true" ]; echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important" > ${SOURCES_LIST_FILE}; fi
     - dpkg -i $OMNIBUS_PACKAGE_DIR/*.deb
+    - rm -f ${SOURCES_LIST_FILE}
     # rebuild the apt database after installing the package with dpkg
     - apt-get install -f
 
@@ -124,7 +132,9 @@ test_ubuntu_14_not_signed_by:
   image: registry.ddbuild.io/images/mirror/ubuntu:18.04
   before_script:
     - apt-get update
+    - if [ "USE_SIGNED_BY" = "true" ]; echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important" > ${SOURCES_LIST_FILE}; fi
     - apt-get install -y $OMNIBUS_PACKAGE_DIR/*.deb debsig-verify
+    - rm -f ${SOURCES_LIST_FILE}
 
 test_ubuntu_18_signed_by:
   extends: .test_ubuntu_18

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,7 +72,7 @@ build_deb:
     - echo -e "deb http://archive.debian.org/debian wheezy main\ndeb http://archive.debian.org/debian-security wheezy/updates main" > /etc/apt/sources.list
     - apt-get update -o Acquire::Check-Valid-Until=false
     - apt-get install -y debsig-verify
-    - if [ "USE_SIGNED_BY" = "true" ]; then echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important" > ${SOURCES_LIST_FILE}; fi
+    - if [ "${USE_SIGNED_BY}" = "true" ]; then echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important" > ${SOURCES_LIST_FILE}; fi
     # apt-get in Debian 7 doesn't work with local packages
     - dpkg -i $OMNIBUS_PACKAGE_DIR/*.deb
     - rm -f ${SOURCES_LIST_FILE}
@@ -92,7 +92,7 @@ test_debian_7_not_signed_by:
   image: registry.ddbuild.io/images/mirror/debian:10.9
   before_script:
     - apt-get update
-    - if [ "USE_SIGNED_BY" = "true" ]; then echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important" > ${SOURCES_LIST_FILE}; fi
+    - if [ "${USE_SIGNED_BY}" = "true" ]; then echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important" > ${SOURCES_LIST_FILE}; fi
     - apt-get install -y $OMNIBUS_PACKAGE_DIR/*.deb debsig-verify
     - rm -f ${SOURCES_LIST_FILE}
 
@@ -113,7 +113,7 @@ test_debian_10_not_signed_by:
     - apt-get update
     - apt-get install -y debsig-verify
     # apt-get in Ubuntu 14 doesn't work with local packages
-    - if [ "USE_SIGNED_BY" = "true" ]; then echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important" > ${SOURCES_LIST_FILE}; fi
+    - if [ "${USE_SIGNED_BY}" = "true" ]; then echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important" > ${SOURCES_LIST_FILE}; fi
     - dpkg -i $OMNIBUS_PACKAGE_DIR/*.deb
     - rm -f ${SOURCES_LIST_FILE}
     # rebuild the apt database after installing the package with dpkg
@@ -132,7 +132,7 @@ test_ubuntu_14_not_signed_by:
   image: registry.ddbuild.io/images/mirror/ubuntu:18.04
   before_script:
     - apt-get update
-    - if [ "USE_SIGNED_BY" = "true" ]; then echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important" > ${SOURCES_LIST_FILE}; fi
+    - if [ "${USE_SIGNED_BY}" = "true" ]; then echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important" > ${SOURCES_LIST_FILE}; fi
     - apt-get install -y $OMNIBUS_PACKAGE_DIR/*.deb debsig-verify
     - rm -f ${SOURCES_LIST_FILE}
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -164,7 +164,7 @@ generate_testing_repo:
   stage: deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main", "size:large"]
-  needs: ["build_deb", "test_debian_7", "test_debian_10", "test_ubuntu_14", "test_ubuntu_18"]
+  needs: ["build_deb", "test_debian_7_signed_by", "test_debian_7_not_signed_by" "test_debian_10_signed_by", "test_debian_10_not_signed_by", "test_ubuntu_14_signed_by", "test_ubuntu_14_not_signed_by", "test_ubuntu_18_signed_by", "test_ubuntu_18_not_signed_by"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,7 +72,7 @@ build_deb:
     - echo -e "deb http://archive.debian.org/debian wheezy main\ndeb http://archive.debian.org/debian-security wheezy/updates main" > /etc/apt/sources.list
     - apt-get update -o Acquire::Check-Valid-Until=false
     - apt-get install -y debsig-verify
-    - if [ "${USE_SIGNED_BY}" = "true" ]; then echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important" > ${SOURCES_LIST_FILE}; fi
+    - if [ "${USE_SIGNED_BY}" = "true" ]; then echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important x y" > ${SOURCES_LIST_FILE}; fi
     # apt-get in Debian 7 doesn't work with local packages
     - dpkg -i $OMNIBUS_PACKAGE_DIR/*.deb
     - rm -f ${SOURCES_LIST_FILE}
@@ -92,7 +92,7 @@ test_debian_7_not_signed_by:
   image: registry.ddbuild.io/images/mirror/debian:10.9
   before_script:
     - apt-get update
-    - if [ "${USE_SIGNED_BY}" = "true" ]; then echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important" > ${SOURCES_LIST_FILE}; fi
+    - if [ "${USE_SIGNED_BY}" = "true" ]; then echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important x y" > ${SOURCES_LIST_FILE}; fi
     - apt-get install -y $OMNIBUS_PACKAGE_DIR/*.deb debsig-verify
     - rm -f ${SOURCES_LIST_FILE}
 
@@ -113,7 +113,7 @@ test_debian_10_not_signed_by:
     - apt-get update
     - apt-get install -y debsig-verify
     # apt-get in Ubuntu 14 doesn't work with local packages
-    - if [ "${USE_SIGNED_BY}" = "true" ]; then echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important" > ${SOURCES_LIST_FILE}; fi
+    - if [ "${USE_SIGNED_BY}" = "true" ]; then echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important x y" > ${SOURCES_LIST_FILE}; fi
     - dpkg -i $OMNIBUS_PACKAGE_DIR/*.deb
     - rm -f ${SOURCES_LIST_FILE}
     # rebuild the apt database after installing the package with dpkg
@@ -132,7 +132,7 @@ test_ubuntu_14_not_signed_by:
   image: registry.ddbuild.io/images/mirror/ubuntu:18.04
   before_script:
     - apt-get update
-    - if [ "${USE_SIGNED_BY}" = "true" ]; then echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important" > ${SOURCES_LIST_FILE}; fi
+    - if [ "${USE_SIGNED_BY}" = "true" ]; then echo "deb [signed-by=${USR_SHARE_KEYRING}] https://not-important x y" > ${SOURCES_LIST_FILE}; fi
     - apt-get install -y $OMNIBUS_PACKAGE_DIR/*.deb debsig-verify
     - rm -f ${SOURCES_LIST_FILE}
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -131,7 +131,7 @@ test_ubuntu_18_signed_by:
   variables:
     USE_SIGNED_BY: "true"
 
-test_ubuntu_18_no_signed_by:
+test_ubuntu_18_not_signed_by:
   extends: .test_ubuntu_18
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,7 +60,7 @@ build_deb:
 # We also ensure that /etc/apt/trusted.gpg.d/datadog-archive-keyring.gpg
 # gets created on Debian 7/Ubuntu 14, since apt in these doesn't respect
 # the `[signed-by=...]` modifier in apt source files.
-test_debian_7:
+.test_debian_7:
   extends: .test_deb
   image: registry.ddbuild.io/images/mirror/debian:7.11
   variables:
@@ -75,14 +75,30 @@ test_debian_7:
     # rebuild the apt database after installing the package with dpkg
     - apt-get install -f
 
-test_debian_10:
+test_debian_7_signed_by:
+  extends: .test_debian_7
+  variables:
+    USE_SIGNED_BY: "true"
+
+test_debian_7_not_signed_by:
+  extends: .test_debian_7
+
+.test_debian_10:
   extends: .test_deb
   image: registry.ddbuild.io/images/mirror/debian:10.9
   before_script:
     - apt-get update
     - apt-get install -y $OMNIBUS_PACKAGE_DIR/*.deb debsig-verify
 
-test_ubuntu_14:
+test_debian_10_signed_by:
+  extends: .test_debian_10
+  variables:
+    USE_SIGNED_BY: "true"
+
+test_debian_10_not_signed_by:
+  extends: .test_debian_10
+
+.test_ubuntu_14:
   extends: .test_deb
   image: registry.ddbuild.io/images/mirror/ubuntu:14.04
   variables:
@@ -95,12 +111,29 @@ test_ubuntu_14:
     # rebuild the apt database after installing the package with dpkg
     - apt-get install -f
 
-test_ubuntu_18:
+test_ubuntu_14_signed_by:
+  extends: .test_ubuntu_14
+  variables:
+    USE_SIGNED_BY: "true"
+
+test_ubuntu_14_not_signed_by:
+  extends: .test_ubuntu_14
+
+.test_ubuntu_18:
   extends: .test_deb
   image: registry.ddbuild.io/images/mirror/ubuntu:18.04
   before_script:
     - apt-get update
     - apt-get install -y $OMNIBUS_PACKAGE_DIR/*.deb debsig-verify
+
+test_ubuntu_18_signed_by:
+  extends: .test_ubuntu_18
+  variables:
+    USE_SIGNED_BY: "true"
+
+test_ubuntu_18_no_signed_by:
+  extends: .test_ubuntu_18
+
 
 generate_testing_repo:
   # You can use this task to generate a testing repository; the repository

--- a/package-scripts/datadog-signing-keys/postinst
+++ b/package-scripts/datadog-signing-keys/postinst
@@ -23,7 +23,14 @@ USE_TRUSTED_GPG_D=true
 DISTRIBUTION_VERSION=$(. /etc/os-release && echo "${VERSION_ID}" | tr "." " " | awk '{ print $1 }')
 
 if { [ "${DISTRIBUTION}" = "Debian" ] && [ "${DISTRIBUTION_VERSION}" -ge "9" ]; } || { [ "${DISTRIBUTION}" = "Ubuntu" ] && [ "${DISTRIBUTION_VERSION}" -ge "16" ]; } ; then
-    USE_TRUSTED_GPG_D=false
+    # We also want to create the /etc/apt/trusted.gpg.d keyring if the system
+    # is not set to use the /usr/share/keyrings/ keyring through signed-by.
+    # This might create the /etc/apt/trusted.gpg.d keyring unnecessarily on
+    # some systems, but it's the only way to be at least somewhat certain
+    # that anyone who installed the package is ok.
+    if grep "signed-by=${USR_SHARE_KEYRING}" /etc/apt/sources.list.d/datadog.list 2>/dev/null 1>/dev/null; then
+        USE_TRUSTED_GPG_D=false
+    fi
 fi
 
 # Always create our keyring at /usr/share/keyring, because the sources list

--- a/test/test.sh
+++ b/test/test.sh
@@ -5,16 +5,10 @@
 # Copyright 2021-present Datadog, Inc.
 
 apt_trusted_keyring="/etc/apt/trusted.gpg.d/datadog-archive-keyring.gpg"
-usr_share_keyring="/usr/share/keyrings/datadog-archive-keyring.gpg"
-sources_list_file="/etc/apt/sources.list.d/datadog.list"
 
 for i in $(ls -d test/repos/*); do
     repo_path=$(pwd)/${i}
-    if [ "${USE_SIGNED_BY}" = "true" ]; then
-        echo "deb [signed-by=${usr_share_keyring}] file://${repo_path} ./" > ${sources_list_file}
-    else
-        echo "deb file://${repo_path} ./" > ${sources_list_file}
-    fi
+    echo "deb [signed-by=${USR_SHARE_KEYRING}] file://${repo_path} ./" > ${SOURCES_LIST_FILE}
 
     # if apt update passes, we correctly recognized repodata signature
     apt-get update

--- a/test/test.sh
+++ b/test/test.sh
@@ -28,7 +28,7 @@ if { [ "${ENSURE_TRUSTED_GPG_D_KEYRING}" = "true" ] || [ -z "${USE_SIGNED_BY}" ]
     exit 1
 fi
 
-if { [ "${ENSURE_TRUSTED_GPG_D_KEYRING}" != "true" ] && [ -n "${USE_SIGNED_BY}" ] } && [ -f ${apt_trusted_keyring} ]; then
+if { [ "${ENSURE_TRUSTED_GPG_D_KEYRING}" != "true" ] && [ -n "${USE_SIGNED_BY}" ]; } && [ -f ${apt_trusted_keyring} ]; then
     echo "${apt_trusted_keyring} exists when it shouldn't"
     exit 1
 fi

--- a/test/test.sh
+++ b/test/test.sh
@@ -6,10 +6,15 @@
 
 apt_trusted_keyring="/etc/apt/trusted.gpg.d/datadog-archive-keyring.gpg"
 usr_share_keyring="/usr/share/keyrings/datadog-archive-keyring.gpg"
+sources_list_file="/etc/apt/sources.list.d/datadog.list"
 
 for i in $(ls -d test/repos/*); do
     repo_path=$(pwd)/${i}
-    echo "deb [signed-by=${usr_share_keyring}] file://${repo_path} ./" > /etc/apt/sources.list.d/datadog.list
+    if [ "${USE_SIGNED_BY}" = "true" ]; then
+        echo "deb [signed-by=${usr_share_keyring}] file://${repo_path} ./" > ${sources_list_file}
+    else
+        echo "deb file://${repo_path} ./" > ${sources_list_file}
+    fi
 
     # if apt update passes, we correctly recognized repodata signature
     apt-get update
@@ -18,12 +23,12 @@ for i in $(ls -d test/repos/*); do
     debsig-verify ${repo_path}/datadog-signing-keys*.deb
 done
 
-if [ "${ENSURE_TRUSTED_GPG_D_KEYRING}" = "true" ] && [ ! -f ${apt_trusted_keyring} ]; then
+if { [ "${ENSURE_TRUSTED_GPG_D_KEYRING}" = "true" ] || [ -z "${USE_SIGNED_BY}" ]; } && [ ! -f ${apt_trusted_keyring} ]; then
     echo "${apt_trusted_keyring} doesn't exist when it should"
     exit 1
 fi
 
-if [ "${ENSURE_TRUSTED_GPG_D_KEYRING}" != "true" ] && [ -f ${apt_trusted_keyring} ]; then
+if { [ "${ENSURE_TRUSTED_GPG_D_KEYRING}" != "true" ] && [ -n "${USE_SIGNED_BY}" ] } && [ -f ${apt_trusted_keyring} ]; then
     echo "${apt_trusted_keyring} exists when it shouldn't"
     exit 1
 fi


### PR DESCRIPTION
We also want to create the /etc/apt/trusted.gpg.d keyring if the system is not set to use the /usr/share/keyrings/ keyring through signed-by. This might create the /etc/apt/trusted.gpg.d keyring unnecessarily on some systems, but it's the only way to be at least somewhat certain that anyone who installed the package is ok.