### PR TITLE
Rotate key used to sign DEB package and staging repodata

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,8 @@
 variables:
   DATADOG_AGENT_BUILDERS: v6397651-8d03f89
   DATADOG_AGENT_BUILDIMAGES: v7335571-19a72d1
-  DEB_GPG_KEY_ID: 8387EEAF
-  DEB_GPG_KEY_NAME: "Datadog, Inc <package@datadoghq.com>"  # used by config/projects/datadog-signing-keys.rb
+  DEB_GPG_KEY_ID: ad9589b7
+  DEB_GPG_KEY_NAME: "Datadog, Inc. Master key"  # used by config/projects/datadog-signing-keys.rb
   DEB_GPG_KEY_SSM_NAME: ci.datadog-agent.deb_signing_private_key_${DEB_GPG_KEY_ID}
   DEB_SIGNING_PASSPHRASE_SSM_NAME: ci.datadog-agent.deb_signing_key_passphrase_${DEB_GPG_KEY_ID}
   DESTINATION_DEB: datadog-signing-keys.deb


### PR DESCRIPTION
This is in line with the datadog-agent key rotation for package signatures + staging repodata: https://github.com/DataDog/datadog-agent/pull/11489