### PR TITLE
Add missing debian policies

### DIFF
--- a/config/projects/datadog-signing-keys.rb
+++ b/config/projects/datadog-signing-keys.rb
@@ -6,7 +6,7 @@
 # Modify this when adding/removing keys; also modify postinst script to add
 # the new key to the APT keyring (I didn't find a reasonable way to make
 # postinst script an omnibus template to render these in).
-keys = ['E6266D4AC0962C7D', '33EE313BAD9589B7', '4B4593018387EEAF']
+keys = ['E6266D4AC0962C7D', '33EE313BAD9589B7', '4B4593018387EEAF', '0D826EB906462314']
 
 name 'datadog-signing-keys'
 maintainer 'Datadog Packages <package@datadoghq.com>'

--- a/config/projects/datadog-signing-keys.rb
+++ b/config/projects/datadog-signing-keys.rb
@@ -6,7 +6,7 @@
 # Modify this when adding/removing keys; also modify postinst script to add
 # the new key to the APT keyring (I didn't find a reasonable way to make
 # postinst script an omnibus template to render these in).
-keys = ['E6266D4AC0962C7D', '33EE313BAD9589B7', '4B4593018387EEAF', '0D826EB906462314']
+keys = %w[E6266D4AC0962C7D 33EE313BAD9589B7 4B4593018387EEAF 0D826EB906462314]
 
 name 'datadog-signing-keys'
 maintainer 'Datadog Packages <package@datadoghq.com>'

--- a/files/policies/0D826EB906462314/datadog-compat.pol
+++ b/files/policies/0D826EB906462314/datadog-compat.pol
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE Policy SYSTEM "https://www.debian.org/debsig/1.0/policy.dtd">
+<!-- older Debian systems (e.g. Debian 7) require policy xmlns to start with http://, not https:// -->
+<Policy xmlns="http://www.debian.org/debsig/1.0/">
+	<Origin Name="Datadog" id="0D826EB906462314" Description="Datadog, Inc" />
+
+	<Selection>
+		<Required Type="origin" File="debsig.gpg" id="0D826EB906462314" />
+	</Selection>
+
+	<Verification MinOptional="0">
+		<Required Type="origin" File="debsig.gpg" id="0D826EB906462314" />
+	</Verification>
+</Policy>

--- a/files/policies/0D826EB906462314/datadog.pol
+++ b/files/policies/0D826EB906462314/datadog.pol
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE Policy SYSTEM "https://www.debian.org/debsig/1.0/policy.dtd">
+<Policy xmlns="https://www.debian.org/debsig/1.0/">
+	<Origin Name="Datadog" id="0D826EB906462314" Description="Datadog, Inc" />
+
+	<Selection>
+		<Required Type="origin" File="debsig.gpg" id="0D826EB906462314" />
+	</Selection>
+
+	<Verification MinOptional="0">
+		<Required Type="origin" File="debsig.gpg" id="0D826EB906462314" />
+	</Verification>
+</Policy>


### PR DESCRIPTION
Fixing error
```
cat: /usr/share/debsig/keyrings/0D826EB906462314/debsig.gpg: No such file or directory
gpg: no valid OpenPGP data found.
```