### PR TITLE
Remove omnibus-software mentions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,4 @@ source 'https://rubygems.org'
 # Install omnibus
 gem 'omnibus', git: 'https://github.com/DataDog/omnibus-ruby.git', branch: (ENV['OMNIBUS_RUBY_VERSION'] || 'datadog-5.5.0')
 
-# Use Chef's software definitions. It is recommended that you write your own
-# software definitions, but you can clone/fork Chef's to get you started.
-gem 'omnibus-software', git: 'https://github.com/DataDog/omnibus-software.git', branch: (ENV['OMNIBUS_SOFTWARE_VERSION'] || 'master')
-
-
 gem 'mixlib-cli', '~> 1.7.0'


### PR DESCRIPTION
Removes all mentions of the https://github.com/DataDog/omnibus-software repository, it is not used by this repository.

The omnibus build done in CI still succeeds.