### PR TITLE
Migrate to artifact-gateway for package promotion

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,7 @@ variables:
   PACKAGE_VERSION_OVERRIDE: ""
   PIPELINE_KEY_ALIAS: "alias/ci_datadog-signing-keys_pipeline-key"
   PROJECT_NAME: datadog-signing-keys
+  DD_PKG_GITLAB_URL: "https://artifact-gateway.us1.ddbuild.io/internal/artifact-gateway/api/v4"
   USR_SHARE_KEYRING: /usr/share/keyrings/datadog-archive-keyring.gpg
   DD_LIST_FILE: /etc/apt/sources.list.d/datadog.list
   OPW_LIST_FILE: /etc/apt/sources.list.d/datadog-observability-pipelines-worker.list

--- a/.gitlab/common.yaml
+++ b/.gitlab/common.yaml
@@ -21,7 +21,6 @@
         OPTIONAL_FLAGS+="--auto-release "
       fi
       if [ "$FOLLOW" = "true" ]; then
-        export GITLAB_TOKEN=$(vault kv get -field=project-token kv/k8s/gitlab-runner/datadog-signing-keys/agent-release-management-read-token)
         OPTIONAL_FLAGS+="--follow"
       fi
     - curl -sSL "https://dd-package-tools.s3.amazonaws.com/dd-pkg/${DD_PKG_VERSION}/dd-pkg_Linux_${DD_PKG_ARCH}.tar.gz" | tar -xz -C /usr/local/bin dd-pkg


### PR DESCRIPTION
Routes `dd-pkg promote` through the artifact-gateway ([BARX-1624](https://datadoghq.atlassian.net/browse/BARX-1624)) by setting `DD_PKG_GITLAB_URL`. The gateway uses internal JWT auth, so the vault-fetched `GITLAB_TOKEN` in the `--follow` path is no longer needed and has been removed.

[BARX-1624]: https://datadoghq.atlassian.net/browse/BARX-1624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ