### PR TITLE
Stop installing dd-pkg at runtime for gitlab_agent_deploy jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,7 @@ include:
 variables:
   DD_PKG_VERSION: latest
   CI_IMAGE_DEB_X64: v47979770-a5a4cfd0
+  CI_IMAGE_GITLAB_AGENT_DEPLOY: v117105987-c5030d62
   DESTINATION_DEB: datadog-signing-keys.deb
   OMNIBUS_BASE_DIR: /.omnibus
   OMNIBUS_PACKAGE_DIR: $CI_PROJECT_DIR/.omnibus/pkg/

--- a/.gitlab/build.yaml
+++ b/.gitlab/build.yaml
@@ -15,9 +15,6 @@ build_deb:
     - bundle install
     - PACKAGE_VERSION=${PACKAGE_VERSION_OVERRIDE:-$RELEASE_VERSION_DEPLOY} bundle exec omnibus build ${PROJECT_NAME} --override=base_dir:${OMNIBUS_BASE_DIR}
     - mkdir -p $OMNIBUS_PACKAGE_DIR && cp $OMNIBUS_BASE_DIR/pkg/datadog-signing-keys*.deb{,.metadata.json} $OMNIBUS_PACKAGE_DIR
-    - !reference [.create-signature-and-lint-packages]
-
-.create-signature-and-lint-packages:
-  - curl -sSL "https://dd-package-tools.s3.amazonaws.com/dd-pkg/${DD_PKG_VERSION}/dd-pkg_Linux_${DD_PKG_ARCH}.tar.gz" | tar -xz -C /usr/local/bin dd-pkg
-  - find ${OMNIBUS_PACKAGE_DIR} -iregex '.*\.\(deb\|rpm\)' | xargs dd-pkg lint || true
-  - dd-pkg sign --key-id "${PIPELINE_KEY_ALIAS}" "${OMNIBUS_PACKAGE_DIR}"
+    - curl -sSL "https://dd-package-tools.s3.amazonaws.com/dd-pkg/${DD_PKG_VERSION}/dd-pkg_Linux_${DD_PKG_ARCH}.tar.gz" | tar -xz -C /usr/local/bin dd-pkg
+    - find ${OMNIBUS_PACKAGE_DIR} -iregex '.*\.\(deb\|rpm\)' | xargs dd-pkg lint || true
+    - dd-pkg sign --key-id "${PIPELINE_KEY_ALIAS}" "${OMNIBUS_PACKAGE_DIR}"

--- a/.gitlab/common.yaml
+++ b/.gitlab/common.yaml
@@ -2,7 +2,7 @@
 # Base job template for package release
 .package-promotion-template:
   stage: promote
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy:$CI_IMAGE_DEB_X64
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy:$CI_IMAGE_GITLAB_AGENT_DEPLOY
   tags: ["arch:amd64"]
   needs:
     - job: upload-linux-packages
@@ -23,7 +23,6 @@
       if [ "$FOLLOW" = "true" ]; then
         OPTIONAL_FLAGS+="--follow"
       fi
-    - curl -sSL "https://dd-package-tools.s3.amazonaws.com/dd-pkg/${DD_PKG_VERSION}/dd-pkg_Linux_${DD_PKG_ARCH}.tar.gz" | tar -xz -C /usr/local/bin dd-pkg
     - dd-pkg promote
       --release-product "${PRODUCT_NAME}"
       --release-version "${RELEASE_VERSION_DEPLOY}"-1

--- a/.gitlab/common.yaml
+++ b/.gitlab/common.yaml
@@ -9,7 +9,6 @@
       artifacts: false
   before_script:
     - export GITLAB_TOKEN=${CI_JOB_TOKEN}
-    - export DD_PKG_ARCH=x86_64
   rules:
     - if: $CI_COMMIT_TAG != null
       when: manual

--- a/.gitlab/promote_testing.yaml
+++ b/.gitlab/promote_testing.yaml
@@ -12,7 +12,7 @@
 # we need to first upload it to supported archs, allowing us to promote the package to the testing repository
 initialize-dummy-packages:
   stage: promote_testing
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy:$CI_IMAGE_DEB_X64
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy:$CI_IMAGE_GITLAB_AGENT_DEPLOY
   tags: ["arch:amd64"]
   rules:
     - when: always

--- a/.gitlab/upload.yaml
+++ b/.gitlab/upload.yaml
@@ -5,7 +5,5 @@ upload-linux-packages:
   tags: ["arch:amd64"]
   rules:
     - when: on_success
-  variables:
-    DD_PKG_ARCH: x86_64
   script:
     - dd-pkg upload "${OMNIBUS_PACKAGE_DIR}" --project-name "${PRODUCT_NAME}"

--- a/.gitlab/upload.yaml
+++ b/.gitlab/upload.yaml
@@ -1,12 +1,11 @@
 ---
 upload-linux-packages:
   stage: upload
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy:$CI_IMAGE_DEB_X64
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy:$CI_IMAGE_GITLAB_AGENT_DEPLOY
   tags: ["arch:amd64"]
   rules:
     - when: on_success
   variables:
     DD_PKG_ARCH: x86_64
   script:
-    - curl -sSL "https://dd-package-tools.s3.amazonaws.com/dd-pkg/${DD_PKG_VERSION}/dd-pkg_Linux_${DD_PKG_ARCH}.tar.gz" | tar -xz -C /usr/local/bin dd-pkg
     - dd-pkg upload "${OMNIBUS_PACKAGE_DIR}" --project-name "${PRODUCT_NAME}"


### PR DESCRIPTION
## What does this PR do?

The `gitlab_agent_deploy` image `v117105987-c5030d62` now ships `dd-pkg` out of the box thanks to [DataDog/datadog-agent-buildimages#1176](https://github.com/DataDog/datadog-agent-buildimages/pull/1176).

This PR:
- Introduces a dedicated `CI_IMAGE_GITLAB_AGENT_DEPLOY` variable (separate from `CI_IMAGE_DEB_X64` which is still used for the `deb_x64` build image) and bumps it to `v117105987-c5030d62`
- Drops the runtime `curl` install of `dd-pkg` in the jobs using that image (`upload-linux-packages`, `.package-promotion-template`)

A follow-up PR will bump `CI_IMAGE_DEB_X64` and potentially merge the two image variables together.

Part of https://datadoghq.atlassian.net/browse/BARX-1781