### PR TITLE
Use linux image for build_deb, remove runtime dd-pkg install

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ include:
 
 variables:
   DD_PKG_VERSION: latest
-  CI_IMAGE_DEB_X64: v47979770-a5a4cfd0
+  CI_IMAGE_LINUX: v117105987-c5030d62
   CI_IMAGE_GITLAB_AGENT_DEPLOY: v117105987-c5030d62
   DESTINATION_DEB: datadog-signing-keys.deb
   OMNIBUS_BASE_DIR: /.omnibus

--- a/.gitlab/build.yaml
+++ b/.gitlab/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_deb:
   stage: build
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64:$CI_IMAGE_DEB_X64
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux:$CI_IMAGE_LINUX
   tags: [arch:amd64]
   variables:
     DD_PKG_ARCH: x86_64
@@ -15,6 +15,5 @@ build_deb:
     - bundle install
     - PACKAGE_VERSION=${PACKAGE_VERSION_OVERRIDE:-$RELEASE_VERSION_DEPLOY} bundle exec omnibus build ${PROJECT_NAME} --override=base_dir:${OMNIBUS_BASE_DIR}
     - mkdir -p $OMNIBUS_PACKAGE_DIR && cp $OMNIBUS_BASE_DIR/pkg/datadog-signing-keys*.deb{,.metadata.json} $OMNIBUS_PACKAGE_DIR
-    - curl -sSL "https://dd-package-tools.s3.amazonaws.com/dd-pkg/${DD_PKG_VERSION}/dd-pkg_Linux_${DD_PKG_ARCH}.tar.gz" | tar -xz -C /usr/local/bin dd-pkg
     - find ${OMNIBUS_PACKAGE_DIR} -iregex '.*\.\(deb\|rpm\)' | xargs dd-pkg lint || true
     - dd-pkg sign --key-id "${PIPELINE_KEY_ALIAS}" "${OMNIBUS_PACKAGE_DIR}"

--- a/.gitlab/build.yaml
+++ b/.gitlab/build.yaml
@@ -3,8 +3,6 @@ build_deb:
   stage: build
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux:$CI_IMAGE_LINUX
   tags: [arch:amd64]
-  variables:
-    DD_PKG_ARCH: x86_64
   artifacts:
     expire_in: 2 weeks
     paths:


### PR DESCRIPTION
## What does this PR do?

Follow-up to #56 ([BARX-1781](https://datadoghq.atlassian.net/browse/BARX-1781)).

- Switches the `build_deb` job from the `deb_x64` image to the `linux` image, which has `dd-pkg` pre-installed
- Removes the runtime `curl` install of `dd-pkg` (no longer needed since the image ships it)
- Removes the now-unused `DD_PKG_ARCH` variable from `build_deb`

This reduces our external dependencies at CI runtime and simplifies the CI configuration.

[BARX-1781]: https://datadoghq.atlassian.net/browse/BARX-1781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ