### PR TITLE
Release 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.4.1 / 2026-06-10
+
+* Migrate to artifact-gateway for package promotion
+* Restructure GitLab CI pipeline; remove omnibus-software dependency
+* Fix integration tests for Debian 10 and deb7
+* Update buildimages; add test for future signing key
+
 # 1.4.0 / 2024-08-27
  
 * Rotate package signing keys (2024 key rotation)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # 1.4.1 / 2026-06-10
 
-* Migrate to artifact-gateway for package promotion
-* Restructure GitLab CI pipeline; remove omnibus-software dependency
 * Fix integration tests for Debian 10 and deb7
 * Update buildimages; add test for future signing key
+* Migrate to new package promotion infrastructure
+* Restructure GitLab CI pipeline; remove omnibus-software dependency
 
 # 1.4.0 / 2024-08-27
  


### PR DESCRIPTION
## Summary

- Add CHANGELOG entry for 1.4.1 patch release
- All changes since 1.4.0 are CI/build infrastructure only — no package functionality changes

## Changes since 1.4.0

- Migrate to artifact-gateway for package promotion (#55)
- Stop installing dd-pkg at runtime for GitLab agent deploy jobs (#56)
- Use linux image for `build_deb`, remove runtime dd-pkg install (#57)
- Restructure GitLab CI pipeline; remove omnibus-software dependency
- Fix integration tests for Debian 10 and deb7
- Update buildimages
- Add test for future signing key

## Release steps (post-merge)

Per https://datadoghq.atlassian.net/wiki/spaces/BARX/pages/3084911934/datadog-signing-keys+package:

1. Tag merged commit: `1.4.1` (no `v` prefix)
2. Trigger `deploy` job in the pipeline for the tag
3. Promote via agent-release-management with version `1.4.1-1`